### PR TITLE
feat(Signin): 네이버 로그인 버튼 추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-NEXT_PUBLIC_BASE_URL=http://localhost:8080
+NEXT_PUBLIC_BASE_URL=https://knitwiki.com
+NEXT_PUBLIC_AUTH_CLIENT_ID_NAVER='__naver_client_id__'

--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-NEXT_PUBLIC_BASE_URL=https://knitwiki.com
-NEXT_PUBLIC_AUTH_CLIENT_ID_NAVER='__naver_client_id__'

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_BASE_URL=http://local-knitwiki.com

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_BASE_URL=http://local-knitwiki.com

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,11 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env files
+.env
+.env.development
+.env.test
+.env.production
 .env.local
 .env.development.local
 .env.test.local

--- a/@types/auth.ts
+++ b/@types/auth.ts
@@ -1,0 +1,4 @@
+export enum SigninType {
+  NAVER = 'signin_type_naver',
+  GOOGLE = 'signin_type_google',
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,7 +3,13 @@ import { VFC } from 'react';
 import { wrapper } from './store';
 import { Layout, Header, Footer } from '~/atoms/layout';
 
-const App: VFC<AppProps> = ({ Component, pageProps }) => {
+const App: VFC<AppProps> = ({ Component, pageProps, router }) => {
+  const { pathname } = router;
+
+  if (pathname.startsWith('/signin')) {
+    return <Component />;
+  }
+
   return (
     <>
       <Header />

--- a/molecules/signin/NaverSigninButton.tsx
+++ b/molecules/signin/NaverSigninButton.tsx
@@ -4,18 +4,22 @@ import { injectSigninSDK } from '~/utils/auth';
 
 const NaverSigninButton: FC = () => {
   useEffect(() => {
-    injectSigninSDK(SigninType.NAVER).then(() => {
-      const naverLogin = new (window as any).naver.LoginWithNaverId({
-        clientId: process.env.NEXT_PUBLIC_AUTH_CLIENT_ID_NAVER,
-        callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/signin/callback/${SigninType.NAVER}`,
-        isPopup: false,
-        loginButton: { color: 'white', type: 3, height: 50 },
-      });
-      naverLogin.init();
-    });
+    injectNaverSigninSDK();
   }, []);
 
   return <div id="naverIdLogin" />;
 };
 
 export default NaverSigninButton;
+
+async function injectNaverSigninSDK() {
+  await injectSigninSDK(SigninType.NAVER);
+
+  const naverLogin = new (window as any).naver.LoginWithNaverId({
+    clientId: process.env.NEXT_PUBLIC_AUTH_CLIENT_ID_NAVER,
+    callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/signin/callback/${SigninType.NAVER}`,
+    isPopup: false,
+    loginButton: { color: 'white', type: 3, height: 50 },
+  });
+  naverLogin.init();
+}

--- a/molecules/signin/NaverSigninButton.tsx
+++ b/molecules/signin/NaverSigninButton.tsx
@@ -1,0 +1,21 @@
+import { FC, useEffect } from 'react';
+import { SigninType } from '~/@types/auth';
+import { injectSigninSDK } from '~/utils/auth';
+
+const NaverSigninButton: FC = () => {
+  useEffect(() => {
+    injectSigninSDK(SigninType.NAVER).then(() => {
+      const naverLogin = new (window as any).naver.LoginWithNaverId({
+        clientId: process.env.NEXT_PUBLIC_AUTH_CLIENT_ID_NAVER,
+        callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/signin/callback/${SigninType.NAVER}`,
+        isPopup: false,
+        loginButton: { color: 'white', type: 3, height: 50 },
+      });
+      naverLogin.init();
+    });
+  }, []);
+
+  return <div id="naverIdLogin" />;
+};
+
+export default NaverSigninButton;

--- a/molecules/signin/NaverSigninButton.tsx
+++ b/molecules/signin/NaverSigninButton.tsx
@@ -12,7 +12,7 @@ const NaverSigninButton: FC = () => {
 
 export default NaverSigninButton;
 
-async function injectNaverSigninSDK() {
+const injectNaverSigninSDK = async () => {
   await injectSigninSDK(SigninType.NAVER);
 
   const naverLogin = new (window as any).naver.LoginWithNaverId({
@@ -22,4 +22,4 @@ async function injectNaverSigninSDK() {
     loginButton: { color: 'white', type: 3, height: 50 },
   });
   naverLogin.init();
-}
+};

--- a/molecules/signin/index.ts
+++ b/molecules/signin/index.ts
@@ -1,0 +1,1 @@
+export { default as NaverSigninButton } from './NaverSigninButton';

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const path = require('path');
 
-['NEXT_PUBLIC_BASE_URL'].forEach((key) => {
+['NEXT_PUBLIC_BASE_URL', 'NEXT_PUBLIC_AUTH_CLIENT_ID_NAVER'].forEach((key) => {
   if (!_.has(process.env, key)) {
     console.error(`${key} is not exist on process environment`);
     process.exit(1);

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,4 +1,0 @@
-const Signin = () => {
-  return <>로그인 페이지</>;
-};
-export default Signin;

--- a/pages/signin/callback/[signinType].tsx
+++ b/pages/signin/callback/[signinType].tsx
@@ -1,0 +1,28 @@
+import { FC, useEffect } from 'react';
+import { useRouter } from 'next/router';
+// import { SigninType } from '~/@types/auth';
+
+const SigninCallback: FC = () => {
+  const router = useRouter();
+  const { signinType, code } = router.query;
+
+  useEffect(() => {
+    // router.query가 초기화가 안된 경우 skip
+    if (!signinType) return;
+
+    // code값이 전달되지 않은 경우 signin 페이지로 redirect
+    if (!code) router.push('/signin');
+
+    /**
+     * Todo
+     * - signinType, code값으로 로그인 API 호출
+     * - response로 내려받은 access token, refresh token 쿠키로 저장
+     * - 필요한 API가 있다면 호출 (유저정보 조회 등)
+     * - 서비스 페이지로 redirect
+     */
+  }, [signinType, code]);
+
+  return <></>;
+};
+
+export default SigninCallback;

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -1,0 +1,11 @@
+import { NaverSigninButton } from '~/molecules/signin';
+
+const Signin = () => {
+  return (
+    <>
+      <NaverSigninButton />
+      {/* <GoogleSigninButton /> */}
+    </>
+  );
+};
+export default Signin;

--- a/utils/auth/index.ts
+++ b/utils/auth/index.ts
@@ -1,0 +1,21 @@
+import { SigninType } from '~/@types/auth';
+
+const SDK_URL: Record<SigninType, string> = {
+  [SigninType.NAVER]: 'https://static.nid.naver.com/js/naveridlogin_js_sdk_2.0.0.js',
+  [SigninType.GOOGLE]: '',
+};
+
+export function injectSigninSDK(type: SigninType) {
+  const id = `${type}_SDK`;
+  if (document.getElementById(id)) return Promise.resolve();
+
+  const scriptElement = document.createElement('script');
+  scriptElement.type = 'text/javascript';
+  scriptElement.src = SDK_URL[type];
+  scriptElement.id = id;
+  document.head.appendChild(scriptElement);
+
+  return new Promise((resolve) => {
+    scriptElement.onload = resolve;
+  });
+}

--- a/utils/auth/index.ts
+++ b/utils/auth/index.ts
@@ -5,7 +5,7 @@ const SDK_URL: Record<SigninType, string> = {
   [SigninType.GOOGLE]: '',
 };
 
-export function injectSigninSDK(type: SigninType) {
+export const injectSigninSDK = (type: SigninType) => {
   const id = `${type}_SDK`;
   if (document.getElementById(id)) return Promise.resolve();
 
@@ -18,4 +18,4 @@ export function injectSigninSDK(type: SigninType) {
   return new Promise((resolve) => {
     scriptElement.onload = resolve;
   });
-}
+};


### PR DESCRIPTION
### Changes
- 로그인 페이지(`/signin`)에 네이버 로그인 버튼 추가하였습니다.
- authorization code 전달받을 콜백용 페이지(`/signin/callback/[signinType]`) 추가하였습니다.

### Comment
- 로그인 페이지 디자인 최종 시안이 안나와서 우선은 그냥 빈페이지에 로그인 버튼만 추가해둔 상태입니다.
- 네이버&구글 client id는 env로 관리하도록 하였고 현재는 해당값 유효하지 않아서 로그인 버튼이 기능하지 않습니다.

### Next
- 구글 로그인 버튼 추가
- 네이버&구글 client id env 추가
- callback url (`/signin/callback/[signinType]`) 네이버&구글 개발자센터 등록