### PR TITLE
문서 편집 / 컨텐츠 영역이 길어지는 경우 사이드패널이 스크롤 따라다니도록 설정

### DIFF
--- a/molecules/thread/SidePannel/SidePannel.styled.ts
+++ b/molecules/thread/SidePannel/SidePannel.styled.ts
@@ -12,6 +12,7 @@ export const Container = styled.div`
   box-shadow: 0px 0px 15px rgba(0, 0, 0, 0.12);
   border-radius: 4px;
 
+  transition: 0.16s ease-out;
   cursor: pointer;
 `;
 

--- a/molecules/thread/SidePannel/SidePannel.tsx
+++ b/molecules/thread/SidePannel/SidePannel.tsx
@@ -1,4 +1,5 @@
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
+import _ from 'lodash';
 import {
   ImageIcon,
   VideoIcon,
@@ -11,8 +12,21 @@ import {
 import { Container, IconContainer } from './SidePannel.styled';
 
 const SidePannel: FC = () => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleScroll = _.throttle(() => {
+      if (!ref.current || !ref.current.parentElement || !document.scrollingElement) return;
+      const diff = 30 - ref.current.parentElement.offsetTop + document.scrollingElement.scrollTop;
+      ref.current.style.transform = `translate(0, ${Math.max(diff, 0)}px)`;
+    }, 15);
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
   return (
-    <Container>
+    <Container ref={ref}>
       <IconContainer>
         <ImageIcon />
       </IconContainer>

--- a/molecules/thread/Tags/Tag.tsx
+++ b/molecules/thread/Tags/Tag.tsx
@@ -18,8 +18,8 @@ const Tag: FC<Props> = ({ id, title, editting, onClickDelete }) => {
 
   return (
     <Container editting={editting}>
-      <DeleteButton sizePx={25} iconSizePx={10} onClick={handleClickDelete} />
-      <TagAtom title={title} onClick={handleClickDelete} />
+      <DeleteButton sizePx={25} iconSizePx={10} onClick={handleClickDelete} tabIndex={-1} />
+      <TagAtom title={title} onClick={handleClickDelete} tabIndex={-1} />
     </Container>
   );
 };

--- a/pages/thread/[id].tsx
+++ b/pages/thread/[id].tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { FC, useState } from 'react';
+import { FC, MouseEventHandler, useState } from 'react';
 import { Color } from '~/@types';
 import { CategoryType, LineType, Thread, ThreadAction } from '~/@types/resources/thread';
 import {
@@ -93,10 +93,18 @@ const ThreadPage: FC = () => {
     setThread({ ...thread, categories: nextCategories });
   };
 
+  // mock data
   const [block, setBlock] = useState('');
 
+  const handleClickCapture: MouseEventHandler<HTMLElement> = (event) => {
+    // 문서 편집 중에는 모든 링크 동작하지 않도록 처리
+    if (isEditMode && (event.target as HTMLElement).tagName === 'A') {
+      event.preventDefault();
+    }
+  };
+
   return (
-    <Container>
+    <Container onClickCapture={handleClickCapture}>
       {isEditMode ? (
         <Tasks action={ThreadAction.EDIT}>
           <ButtonTask onClick={() => router.push(`/thread/${id}`)}>취소</ButtonTask>


### PR DESCRIPTION
### Changes
- https://github.com/bsideproject/knit-frontend/pull/101/commits/37ccb3b9f0e73de6ecb15b731e7f82cb5d4ee063 태그에 포커스 불가능 하도록 처리하였습니다. (서브 타이틀 입력 이후 탭키 입력 시 컨텐츠 영역에 포커스 될 수 있도록)
- https://github.com/bsideproject/knit-frontend/pull/101/commits/0be7381d9c7e85f4fc5a6966c39f98efe99415bc 문서 편집 중에는 페이지 내 a링크들이 라우팅을 수행하지 않도록 처리하였습니다.
- https://github.com/bsideproject/knit-frontend/pull/101/commits/17c42b7ab73e9ab3e8069b487cc14167f52a9bb6 컨텐츠 영역이 길어지는 경우 사이드 패널이 스크롤을 따라다니도록 하였습니다.

![Apr-11-2021 22-36-46](https://user-images.githubusercontent.com/34727284/114306300-7a65a680-9b16-11eb-8a46-eee98e5b8506.gif)
