### PR TITLE
문서 편집 / TextContent 기본 동작 추가

### DIFF
--- a/@types/resources/thread.ts
+++ b/@types/resources/thread.ts
@@ -14,7 +14,7 @@ export interface Thread {
   /* 문서 태그 리스트 */
   tags: ReadonlyArray<{ id: number; value: string }>;
   /* 문서 본문 */
-  contents: ReadonlyArray<TextLine | ImageLine | CodeLine | DeviderLine>;
+  contents: ReadonlyArray<TextContent | ImageContent | CodeContent | DeviderContent>;
   /* 문서 작성 시간 */
   modifiedDateTime: number;
 }
@@ -28,31 +28,32 @@ export enum CategoryType {
   ETC = 'ETC',
 }
 
-export enum LineType {
+export enum ContentType {
   TEXT = 'TEXT',
   IMAGE = 'IMAGE',
   CODE = 'CODE',
   DEVIDER = 'DEVIDER',
 }
 
-interface Line<T extends keyof typeof LineType> {
+interface Content<T extends keyof typeof ContentType> {
+  id: number;
   type: T;
 }
 
-export interface TextLine extends Line<LineType.TEXT> {
+export interface TextContent extends Content<ContentType.TEXT> {
   value: string;
 }
 
-export interface ImageLine extends Line<LineType.IMAGE> {
+export interface ImageContent extends Content<ContentType.IMAGE> {
   value: string;
 }
 
-export interface CodeLine extends Line<LineType.CODE> {
+export interface CodeContent extends Content<ContentType.CODE> {
   value: string;
   format: CodeFormat;
 }
 
-export interface DeviderLine extends Line<LineType.DEVIDER> {}
+export interface DeviderContent extends Content<ContentType.DEVIDER> {}
 
 export type CodeFormat = 'javascript' | 'json' | void;
 

--- a/molecules/thread/Block/Block.styled.ts
+++ b/molecules/thread/Block/Block.styled.ts
@@ -9,6 +9,8 @@ export const Container = styled(ContentEditable as any)<Omit<BlockProps, 'onChan
   padding: 10px;
 
   ${font.set(16)}
+  white-space: pre-wrap;
+  word-break: break-word;
   border-radius: 4px;
 
   outline: none;
@@ -22,6 +24,7 @@ export const Container = styled(ContentEditable as any)<Omit<BlockProps, 'onChan
         position: relative;
         top: 2px;
         color: #e2e1eb;
+        font-weight: bold;
         cursor: text;
         pointer-events: none;
       }

--- a/molecules/thread/Block/Block.tsx
+++ b/molecules/thread/Block/Block.tsx
@@ -61,11 +61,11 @@ const Block: FC<BlockProps> = ({
     onChangeRef.current?.(event);
   };
 
-  const handleKeyPress = (event: ContentEditableEvent & globalThis.KeyboardEvent) => {
+  const handleKeyPress = (event: ContentEditableEvent & KeyboardEvent) => {
     onKeyPressRef.current?.(event);
   };
 
-  const handleKeyDown = (event: ContentEditableEvent & globalThis.KeyboardEvent) => {
+  const handleKeyDown = (event: ContentEditableEvent & KeyboardEvent) => {
     onKeyDownRef.current?.(event);
   };
 

--- a/molecules/thread/Block/Block.tsx
+++ b/molecules/thread/Block/Block.tsx
@@ -1,32 +1,72 @@
 import styled from '@emotion/styled';
-import { FC, KeyboardEvent, useRef } from 'react';
+import { FC, useEffect, useRef } from 'react';
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable';
+import { setCaretPos } from '~/utils/dom';
+import { useWatchRef } from './helpers';
 import { Container } from './Block.styled';
-import { BlockProps } from './types';
+import { BlockProps, FocusType } from './types';
 
 const Block: FC<BlockProps> = ({
   className,
   editable = false,
-  multiline = true,
   placeholder,
   value,
+  focusInfo,
+  onFocus = () => {},
+  onBlur = () => {},
   onChange = () => {},
-  onKeyPressEnter,
+  onKeyPress = () => {},
+  onKeyDown = () => {},
 }) => {
+  const valueRef = useWatchRef<BlockProps['value']>(value);
+  const onFocusRef = useWatchRef<BlockProps['onFocus']>(onFocus);
+  const onBlurRef = useWatchRef<BlockProps['onBlur']>(onBlur);
+  const onChangeRef = useWatchRef<BlockProps['onChange']>(onChange);
+  const onKeyPressRef = useWatchRef<BlockProps['onKeyPress']>(onKeyPress);
+  const onKeyDownRef = useWatchRef<BlockProps['onKeyDown']>(onKeyDown);
+
   const domRef = useRef<ContentEditable>();
 
-  const handleChange = ({ target }: ContentEditableEvent) => {
-    onChange(target.value ?? '');
+  useEffect(() => {
+    if (!focusInfo) return;
+    const { focusType } = focusInfo;
+
+    if (focusType === FocusType.PASSIVE) return;
+
+    const element = domRef.current?.el.current;
+    if (!element) return;
+
+    if (focusType === FocusType.FIRST_CARET) {
+      setCaretPos(element, 0);
+      return;
+    }
+    if (focusType === FocusType.LAST_CARET) {
+      setCaretPos(element, valueRef.current?.length ?? 0);
+      return;
+    }
+    if (focusType === FocusType.DESIGNATE_CARET) {
+      setCaretPos(element, (focusInfo as { focusCaretPos: number }).focusCaretPos);
+    }
+  }, [focusInfo]);
+
+  const handleFocus = () => {
+    onFocusRef.current?.();
   };
 
-  const handleKeyPress = (event: ContentEditableEvent & KeyboardEvent) => {
-    const { key, shiftKey } = event;
+  const handleBlur = () => {
+    onBlurRef.current?.();
+  };
 
-    if (key === 'Enter') {
-      if (multiline && shiftKey) return;
-      event.preventDefault();
-      onKeyPressEnter?.(domRef.current?.el.current);
-    }
+  const handleChange = (event: ContentEditableEvent) => {
+    onChangeRef.current?.(event);
+  };
+
+  const handleKeyPress = (event: ContentEditableEvent & globalThis.KeyboardEvent) => {
+    onKeyPressRef.current?.(event);
+  };
+
+  const handleKeyDown = (event: ContentEditableEvent & globalThis.KeyboardEvent) => {
+    onKeyDownRef.current?.(event);
   };
 
   return (
@@ -40,8 +80,11 @@ const Block: FC<BlockProps> = ({
       placeholder={placeholder}
       disabled={!editable}
       html={value ?? ''}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       onChange={handleChange}
       onKeyPress={handleKeyPress}
+      onKeyDown={handleKeyDown}
     />
   );
 };

--- a/molecules/thread/Block/helpers.ts
+++ b/molecules/thread/Block/helpers.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { BlockElement } from './types';
 
 /**
@@ -14,4 +15,14 @@ export const getNextBlockElement = (currentBlockElement: BlockElement) => {
   });
   if (currentIndex === -1 || blockElements.length === currentIndex + 1) return null;
   return blockElements[currentIndex + 1] as BlockElement;
+};
+
+export const useWatchRef = <T = any>(payload: T) => {
+  const ref = useRef<T>(payload);
+
+  useEffect(() => {
+    ref.current = payload;
+  }, [payload]);
+
+  return ref;
 };

--- a/molecules/thread/Block/types.ts
+++ b/molecules/thread/Block/types.ts
@@ -1,11 +1,32 @@
+import { ContentEditableEvent } from 'react-contenteditable';
+
 export interface BlockProps {
   editable?: boolean;
   className?: string;
-  multiline?: boolean;
   placeholder?: string;
   value?: string;
-  onChange?: (value: string) => void;
-  onKeyPressEnter?: (element: HTMLDivElement) => void;
+  focusInfo?: FocusInfo;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  onChange?: (event: ContentEditableEvent) => void;
+  onKeyPress?: (event: ContentEditableEvent & globalThis.KeyboardEvent) => void;
+  onKeyDown?: (event: ContentEditableEvent & globalThis.KeyboardEvent) => void;
 }
 
 export type BlockElement = HTMLDivElement;
+
+export type FocusInfo =
+  | {
+      focusType: FocusType.DESIGNATE_CARET;
+      focusCaretPos: number;
+    }
+  | {
+      focusType: FocusType.PASSIVE | FocusType.FIRST_CARET | FocusType.LAST_CARET;
+    };
+
+export enum FocusType {
+  PASSIVE = 1,
+  FIRST_CARET,
+  LAST_CARET,
+  DESIGNATE_CARET,
+}

--- a/molecules/thread/Block/types.ts
+++ b/molecules/thread/Block/types.ts
@@ -9,8 +9,8 @@ export interface BlockProps {
   onFocus?: () => void;
   onBlur?: () => void;
   onChange?: (event: ContentEditableEvent) => void;
-  onKeyPress?: (event: ContentEditableEvent & globalThis.KeyboardEvent) => void;
-  onKeyDown?: (event: ContentEditableEvent & globalThis.KeyboardEvent) => void;
+  onKeyPress?: (event: ContentEditableEvent & KeyboardEvent) => void;
+  onKeyDown?: (event: ContentEditableEvent & KeyboardEvent) => void;
 }
 
 export type BlockElement = HTMLDivElement;

--- a/molecules/thread/Contents/Contents.styled.ts
+++ b/molecules/thread/Contents/Contents.styled.ts
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { resolveProp } from '~/utils/styles';
+import { Block } from '../Block';
+
+export const Container = styled.div<{ isEditMode: boolean }>`
+  position: relative;
+  ${resolveProp('isEditMode', {
+    true: css`
+      padding-right: 70px;
+    `,
+  })}
+  margin-top: 30px;
+  margin-bottom: 100px;
+
+  min-height: 400px;
+  cursor: text;
+
+  & > ${Block} {
+    margin-bottom: 10px;
+  }
+`;

--- a/molecules/thread/Contents/Contents.tsx
+++ b/molecules/thread/Contents/Contents.tsx
@@ -54,7 +54,7 @@ const Contents: FC<Props> = ({ isEditMode, contents, onChangeContents }) => {
   };
 
   const createKeyPressHandler = (index: number) => (
-    event: ContentEditableEvent & globalThis.KeyboardEvent
+    event: ContentEditableEvent & KeyboardEvent
   ) => {
     const { key, shiftKey, target } = event;
 

--- a/molecules/thread/Contents/Contents.tsx
+++ b/molecules/thread/Contents/Contents.tsx
@@ -1,0 +1,200 @@
+import { FC, MouseEventHandler, useState } from 'react';
+import { ContentEditableEvent } from 'react-contenteditable';
+import { ContentType, TextContent, Thread } from '~/@types/resources/thread';
+import { Block } from '../Block';
+import { createTextContent } from './helpers';
+import { SidePannel } from '../SidePannel';
+import { Container } from './Contents.styled';
+import { FocusInfo, FocusType } from '../Block/types';
+import { getCaretPos } from '~/utils/dom';
+
+interface Props {
+  isEditMode: boolean;
+  contents: Thread['contents'];
+  onChangeContents: (contents: Thread['contents']) => void;
+}
+
+const Contents: FC<Props> = ({ isEditMode, contents, onChangeContents }) => {
+  const [focusInfo, setFocusInfo] = useState<{ contentId: number } & FocusInfo>();
+
+  const handleClickEmptySpace: MouseEventHandler = (event) => {
+    if (event.target !== event.currentTarget) return;
+
+    // contents가 하나도 없는 경우 text content를 생성한 뒤 focus
+    if (contents.length === 0) {
+      const content = createTextContent();
+      onChangeContents([content]);
+      setFocusInfo({
+        contentId: content.id,
+        focusType: FocusType.LAST_CARET,
+      });
+    }
+    // 마지막 content에 focus
+    setFocusInfo({
+      contentId: contents[contents.length - 1].id,
+      focusType: FocusType.LAST_CARET,
+    });
+  };
+
+  const createFocusHandler = (id: number) => () => {
+    setFocusInfo({
+      contentId: id,
+      focusType: FocusType.PASSIVE,
+    });
+  };
+
+  const handleBlur = () => {
+    setFocusInfo(undefined);
+  };
+
+  const createChangeHandler = (index: number) => (event: ContentEditableEvent) => {
+    const value = event.target.value ?? '';
+    const content = { ...contents[index], value };
+    onChangeContents([...contents.slice(0, index), content, ...contents.slice(index + 1)]);
+  };
+
+  const createKeyPressHandler = (index: number) => (
+    event: ContentEditableEvent & globalThis.KeyboardEvent
+  ) => {
+    const { key, shiftKey, target } = event;
+
+    if (key === 'Enter') {
+      if (shiftKey) return;
+      event.preventDefault();
+
+      // 다음 위치에 text content를 생성한 뒤 focus
+      const caretPos = getCaretPos(target);
+      const currOrigContent = contents[index] as TextContent;
+      const currContent = {
+        ...currOrigContent,
+        ...(caretPos !== null ? { value: currOrigContent.value.slice(0, caretPos) } : null),
+      };
+      const nextContent = createTextContent(
+        caretPos !== null ? currOrigContent.value.slice(caretPos) : ''
+      );
+      onChangeContents([
+        ...contents.slice(0, index),
+        currContent,
+        nextContent,
+        ...contents.slice(index + 1),
+      ]);
+      setFocusInfo({
+        contentId: nextContent.id,
+        focusType: FocusType.FIRST_CARET,
+      });
+    }
+  };
+
+  const createKeyDownHandler = (index: number) => (event: ContentEditableEvent & KeyboardEvent) => {
+    const { key, shiftKey, metaKey, target } = event;
+
+    if (key === 'Backspace') {
+      // 첫번째 content인 경우 pass
+      if (index === 0) return;
+      // content가 1개인 경우 pass
+      if (contents.length === 1) return;
+
+      const caretPos = getCaretPos(target);
+      // caret이 첫번째 위치가 아닌 경우 pass
+      if (caretPos !== 0) return;
+
+      // content 제거 및 이전 or 다음 content focus
+      const currOrigContent = contents[index] as TextContent;
+      const prevOrigContent = contents[index - 1] as TextContent;
+      const prevContent = {
+        ...prevOrigContent,
+        ...(caretPos !== null
+          ? { value: `${prevOrigContent.value}${currOrigContent.value}` }
+          : null),
+      };
+      onChangeContents([
+        ...contents.slice(0, index - 1),
+        prevContent,
+        ...contents.slice(index + 1),
+      ]);
+      setFocusInfo({
+        contentId: prevContent.id,
+        focusType: FocusType.DESIGNATE_CARET,
+        focusCaretPos: prevOrigContent.value.length,
+      });
+      return;
+    }
+
+    if (key === 'Tab') {
+      // 첫번째 content & back tab인 경우 pass
+      if (index === 0 && shiftKey) return;
+
+      // 마지막 content인 경우 pass
+      if (index === contents.length - 1) return;
+
+      event.preventDefault();
+      setFocusInfo({
+        contentId: shiftKey ? contents[index - 1].id : contents[index + 1].id,
+        focusType: FocusType.LAST_CARET,
+      });
+    }
+
+    if (key === 'ArrowUp') {
+      // 첫번째 content인 경우 pass
+      if (index === 0) return;
+
+      const caretPos = getCaretPos(target);
+
+      // caret이 첫번째 위치가 아닌 경우 pass
+      if (caretPos !== 0 && !metaKey) return;
+
+      event.preventDefault();
+      setFocusInfo({
+        contentId: contents[index - 1].id,
+        focusType: FocusType.LAST_CARET,
+      });
+      return;
+    }
+
+    if (key === 'ArrowDown') {
+      // 마지막 content인 경우 pass
+      if (index === contents.length - 1) return;
+
+      const caretPos = getCaretPos(target);
+      const content = contents[index] as TextContent;
+
+      // caret이 마지막 위치가 아닌 경우 pass
+      if (caretPos !== content.value.length && !metaKey) return;
+
+      event.preventDefault();
+      setFocusInfo({
+        contentId: contents[index + 1].id,
+        focusType: FocusType.FIRST_CARET,
+      });
+    }
+  };
+
+  return (
+    <Container isEditMode={isEditMode} onClick={handleClickEmptySpace}>
+      {isEditMode && <SidePannel />}
+      {/* {isEditMode && <InlinePannel />} */}
+      {contents.map((content, index) => {
+        switch (content.type) {
+          case ContentType.TEXT:
+            return (
+              <Block
+                key={content.id}
+                editable={isEditMode}
+                value={content.value}
+                focusInfo={content.id === focusInfo?.contentId ? focusInfo : undefined}
+                onFocus={createFocusHandler(content.id)}
+                onBlur={handleBlur}
+                onChange={createChangeHandler(index)}
+                onKeyPress={createKeyPressHandler(index)}
+                onKeyDown={createKeyDownHandler(index)}
+              />
+            );
+          default:
+            return null;
+        }
+      })}
+    </Container>
+  );
+};
+
+export default Contents;

--- a/molecules/thread/Contents/helpers.ts
+++ b/molecules/thread/Contents/helpers.ts
@@ -1,0 +1,6 @@
+import { ContentType, TextContent } from '~/@types/resources/thread';
+
+// mock
+export const createTextContent = (value = ''): TextContent => {
+  return { id: Date.now(), type: ContentType.TEXT, value };
+};

--- a/molecules/thread/Contents/index.ts
+++ b/molecules/thread/Contents/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Contents';

--- a/molecules/thread/Layout.styled.ts
+++ b/molecules/thread/Layout.styled.ts
@@ -72,16 +72,3 @@ export const Devider = styled.hr`
   border: none;
   border-bottom: 1px solid #eee;
 `;
-
-export const Contents = styled.div<{ isEditMode: boolean }>`
-  position: relative;
-  ${resolveProp('isEditMode', {
-    true: css`
-      padding-right: 70px;
-    `,
-  })}
-  margin-top: 30px;
-
-  min-height: 400px;
-  cursor: text;
-`;

--- a/molecules/thread/index.ts
+++ b/molecules/thread/index.ts
@@ -5,3 +5,4 @@ export { default as ModifiedDateTime } from './ModifiedDateTime';
 export { default as Meta } from './Meta';
 export { default as Category } from './Category';
 export { default as Tags } from './Tags';
+export { default as Contents } from './Contents';

--- a/pages/signin/callback/[signinType].tsx
+++ b/pages/signin/callback/[signinType].tsx
@@ -8,7 +8,7 @@ const SigninCallback: FC = () => {
   const { signinType } = router.query;
 
   useEffect(() => {
-    // router.query가 초기화가 안된 경우 skip
+    // router.query가 초기화가 안된 경우 pass
     if (!signinType) return;
 
     if (signinType === SigninType.NAVER) {

--- a/pages/thread/[id].tsx
+++ b/pages/thread/[id].tsx
@@ -62,7 +62,7 @@ const ThreadPage: FC = () => {
     console.log(thumbnailUrl);
   };
 
-  const handleKeyPress = (event: ContentEditableEvent & globalThis.KeyboardEvent) => {
+  const handleKeyPress = (event: ContentEditableEvent & KeyboardEvent) => {
     const { key, shiftKey, target } = event;
 
     if (key === 'Enter') {

--- a/utils/dom/index.ts
+++ b/utils/dom/index.ts
@@ -7,15 +7,13 @@
  */
 import { useEffect, useRef } from 'react';
 
-export const getCaretPos = (
-  target: HTMLDivElement | HTMLInputElement | HTMLTextAreaElement
-): number | null => {
+export const getCaretPos = (target: any): number | null => {
   // for texterea/input element
   if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
     return target.selectionStart;
   }
   // for contentedit field
-  if (target && target.contentEditable) {
+  if (target instanceof HTMLDivElement && target.contentEditable) {
     target.focus();
     const _range = document.getSelection()!.getRangeAt(0);
     const range = _range.cloneRange();
@@ -41,10 +39,15 @@ export const setCaretPos = (
   // for contentedit field
   if (target && target.contentEditable) {
     target.focus();
-    try {
-      document.getSelection()?.collapse(target, pos);
-    } catch (error) {
-      console.error(error);
+    const textNode = target.childNodes[0];
+    if (textNode) {
+      const selection = window.getSelection();
+      if (!selection) return;
+      const range = document.createRange();
+      range.setStart(textNode, pos);
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
     }
   }
 };


### PR DESCRIPTION
### Changes
- Contents 영역 내 텍스트 블록의 기본동작을 추가하였습니다.
  - 텍스트 수정
  - 텍스트 블록 추가
  - 텍스트 블록 삭제
  - 키보드로 텍스트 블록 간 이동

### Comment
- 자세한 내용은 [노션](https://www.notion.so/bside/knit-editor-spec-842ff90aa01c42599f88cfa8fe8d2eae)에 정리해두었으니 참고 부탁드립니다.
- 부모 컴포넌트(`/molecules/thread/Contents/Contents.tsx`)에서 자식 컴포넌트(`/molecules/thread/Block/Block.tsx`)의 focus를 컨트롤하는게 조금 까다로웠는데요, 부모컴포넌트에서 focus상태를 오브젝트로 만들어 prop으로 내려주면 자식컴포넌트에서 effect hook으로 dom을 컨트롤하도록 구현해두었습니다.