### PR TITLE
문서 편집 / 성능 최적화 (컴포넌트 memoization 적용)

### DIFF
--- a/atoms/tag/Tag.tsx
+++ b/atoms/tag/Tag.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { AnchorHTMLAttributes, DetailedHTMLProps, VFC } from 'react';
+import { AnchorHTMLAttributes, DetailedHTMLProps, memo, VFC } from 'react';
 import { ITag } from '~/@types';
 import { Anchor } from './Tag.styled';
 
@@ -30,4 +30,4 @@ const Tag: VFC<TagProps> = ({ url, title, className, onClick, ...restProps }) =>
     </Anchor>
   );
 };
-export default styled(Tag)``;
+export default styled(memo(Tag))``;

--- a/molecules/thread/Block/Block.tsx
+++ b/molecules/thread/Block/Block.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { FC, useEffect, useRef } from 'react';
+import { FC, memo, useEffect, useRef } from 'react';
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable';
 import { setCaretPos } from '~/utils/dom';
 import { useWatchRef } from './helpers';
@@ -89,4 +89,4 @@ const Block: FC<BlockProps> = ({
   );
 };
 
-export default styled(Block)``;
+export default styled(memo<FC<BlockProps>>(Block))``;

--- a/molecules/thread/Category/Category.tsx
+++ b/molecules/thread/Category/Category.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC, memo, ReactNode } from 'react';
 import { CategoryType } from '~/@types/resources/thread';
 import { Container, IconWrapper, IconBorder, Label, IconContainer } from './Category.styled';
 
@@ -41,4 +41,4 @@ const Category: FC<Props> = ({ type, isEditMode, selected, onClick }) => {
   );
 };
 
-export default Category;
+export default memo<FC<Props>>(Category);

--- a/molecules/thread/Contents/Contents.tsx
+++ b/molecules/thread/Contents/Contents.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEventHandler, useState } from 'react';
+import { FC, memo, MouseEventHandler, useState } from 'react';
 import { ContentEditableEvent } from 'react-contenteditable';
 import { ContentType, TextContent, Thread } from '~/@types/resources/thread';
 import { Block } from '../Block';
@@ -197,4 +197,4 @@ const Contents: FC<Props> = ({ isEditMode, contents, onChangeContents }) => {
   );
 };
 
-export default Contents;
+export default memo<FC<Props>>(Contents);

--- a/molecules/thread/Cover/Cover.tsx
+++ b/molecules/thread/Cover/Cover.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import { promptFileSelector } from '~/utils/file';
 import { Container, Image, ImageChangeButton, ImageWrapper, TaskButton } from './Cover.styled';
 import { CoverProps } from './types';
@@ -49,4 +49,4 @@ const Cover: FC<CoverProps> = ({ url, editable, onChange }) => {
   );
 };
 
-export default Cover;
+export default memo<FC<CoverProps>>(Cover);

--- a/molecules/thread/Layout.styled.ts
+++ b/molecules/thread/Layout.styled.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
+import { memo } from 'react';
 import { fitInResolutionOnPage } from '~/styles/layout';
 import * as font from '~/styles/font';
 import { ThreadAction } from '~/@types/resources/thread';
@@ -38,7 +39,7 @@ export const Tasks = styled.div<{ action?: ThreadAction | undefined }>`
   })}
 `;
 
-export const TitleBlock = styled(Block)<BlockProps>`
+export const TitleBlock = styled(memo(Block))<BlockProps>`
   ${font.set(40, 'bold')};
   line-height: 50px;
 
@@ -52,7 +53,7 @@ export const TitleBlock = styled(Block)<BlockProps>`
   })}
 `;
 
-export const SubTitleBlock = styled(Block)<BlockProps>`
+export const SubTitleBlock = styled(memo(Block))<BlockProps>`
   margin-top: 10px;
   display: block;
 

--- a/molecules/thread/Meta/Meta.tsx
+++ b/molecules/thread/Meta/Meta.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC, memo, ReactNode } from 'react';
 import { Container, Required, Label, Contents } from './Meta.styled';
 
 interface Props {
@@ -18,4 +18,4 @@ const Meta: FC<Props> = ({ label, required = false, children }) => {
   );
 };
 
-export default Meta;
+export default memo<FC<Props>>(Meta);

--- a/molecules/thread/SidePannel/SidePannel.tsx
+++ b/molecules/thread/SidePannel/SidePannel.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef } from 'react';
+import { FC, memo, useEffect, useRef } from 'react';
 import _ from 'lodash';
 import {
   ImageIcon,
@@ -56,4 +56,4 @@ const SidePannel: FC = () => {
   );
 };
 
-export default SidePannel;
+export default memo<FC>(SidePannel);

--- a/molecules/thread/Tags/Tag.tsx
+++ b/molecules/thread/Tags/Tag.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import { Container, DeleteButton } from './Tag.styled';
 import { Tag as TagAtom } from '~/atoms/tag';
 
@@ -11,9 +11,7 @@ interface Props {
 
 const Tag: FC<Props> = ({ id, title, editting, onClickDelete }) => {
   const handleClickDelete = () => {
-    if (editting) {
-      onClickDelete(id);
-    }
+    if (editting) onClickDelete(id);
   };
 
   return (
@@ -24,4 +22,4 @@ const Tag: FC<Props> = ({ id, title, editting, onClickDelete }) => {
   );
 };
 
-export default Tag;
+export default memo<FC<Props>>(Tag);

--- a/molecules/thread/Tags/Tags.tsx
+++ b/molecules/thread/Tags/Tags.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, memo, useEffect, useMemo, useRef, useState } from 'react';
 import { setCaretPos, useOnClickOutside } from '~/utils/dom';
 import TagInput from './TagInput';
 import Tag from './Tag';
@@ -47,9 +47,9 @@ const Tags: FC<Props> = ({ isEditMode, tags, onChange }) => {
     inputValue.current = '';
   };
 
-  const handleClickDelete = (id: number) => {
-    onChange(tags.filter((tag) => tag.id !== id));
-  };
+  const handleClickDelete = useMemo(() => {
+    return (id: number) => onChange(tags.filter((tag) => tag.id !== id));
+  }, [tags, onChange]);
 
   const containerRef = useOnClickOutside<HTMLDivElement>(handleCancel);
 
@@ -73,4 +73,4 @@ const Tags: FC<Props> = ({ isEditMode, tags, onChange }) => {
   );
 };
 
-export default Tags;
+export default memo<FC<Props>>(Tags);

--- a/molecules/thread/Task/ButtonTask.tsx
+++ b/molecules/thread/Task/ButtonTask.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import { Color, Size } from '~/@types';
 import { ButtonProps } from '~/atoms/button/ButtonStyled';
 import { StyledButton } from './ButtonTask.styled';
@@ -13,4 +13,4 @@ const ButtonTask: FC<Props> = ({ children, ...restProps }) => {
   );
 };
 
-export default ButtonTask;
+export default memo<FC<Props>>(ButtonTask);

--- a/molecules/thread/Task/LinkTask.tsx
+++ b/molecules/thread/Task/LinkTask.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC, memo, ReactNode } from 'react';
 import Link from 'next/link';
 import { Anchor } from './LinkTask.styled';
 
@@ -15,4 +15,4 @@ const Task: FC<Props> = ({ href, children }) => {
   );
 };
 
-export default Task;
+export default memo<FC<Props>>(Task);

--- a/pages/thread/[id].tsx
+++ b/pages/thread/[id].tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { FC, MouseEventHandler, useState } from 'react';
+import { FC, MouseEventHandler, useCallback, useState } from 'react';
 import { ContentEditableEvent } from 'react-contenteditable';
 import { Color } from '~/@types';
 import { CategoryType, ContentType, Thread, ThreadAction } from '~/@types/resources/thread';
@@ -58,6 +58,8 @@ const ThreadPage: FC = () => {
     modifiedDateTime: Date.now(),
   });
 
+  const handleClickCancelEdit = useCallback(() => router.push(`/thread/${id}`), []);
+
   const handleChangeCover = (thumbnailUrl: string | null) => {
     console.log(thumbnailUrl);
   };
@@ -94,7 +96,7 @@ const ThreadPage: FC = () => {
     <Container onClickCapture={handleClickCaptureContainer}>
       {isEditMode ? (
         <Tasks action={ThreadAction.EDIT}>
-          <ButtonTask onClick={() => router.push(`/thread/${id}`)}>취소</ButtonTask>
+          <ButtonTask onClick={handleClickCancelEdit}>취소</ButtonTask>
           <ButtonTask color={Color.PRIMARY}>등록</ButtonTask>
         </Tasks>
       ) : (


### PR DESCRIPTION
### Changes
- 문서 편집 페이지 내 컴포넌트들에 memoization 적용하였습니다.

### Comment
- 텍스트필드 하나 만들어서 `123456789123456789` 입력하는 걸로 퍼포먼스 측정해보았는데 scripting 시간이 9~10% 정도 절감되네요. (예상대로 효과가 드라마틱하진 않네요 ^^;;)

#### Memoization 적용 전
![image](https://user-images.githubusercontent.com/34727284/115026363-5da5e600-9efd-11eb-92d2-a8120de2c7d4.png)

#### Memoization 적용 후
![image](https://user-images.githubusercontent.com/34727284/115026246-39e2a000-9efd-11eb-8797-e03840819eca.png)
