### PR TITLE
문서 편집 / 사이드패널 이모티콘 입력 기능 추가

### DIFF
--- a/@types/resources/thread.ts
+++ b/@types/resources/thread.ts
@@ -33,9 +33,10 @@ export enum ContentType {
   IMAGE = 'IMAGE',
   CODE = 'CODE',
   DEVIDER = 'DEVIDER',
+  EMOJI = 'EMOJI',
 }
 
-interface Content<T extends keyof typeof ContentType> {
+export interface Content<T extends ContentType> {
   id: number;
   type: T;
 }

--- a/@types/style.ts
+++ b/@types/style.ts
@@ -23,6 +23,7 @@ export enum Size {
 
 export enum CSSzIndex {
   THREAD_PAGE_TASKS = 1,
+  THREAD_SIDE_PANNEL,
   GLOBAL_HEADER,
   GLOBAL_MODAL,
 }

--- a/molecules/thread/SidePannel/EmojiPicker.tsx
+++ b/molecules/thread/SidePannel/EmojiPicker.tsx
@@ -1,0 +1,38 @@
+import dynamic from 'next/dynamic';
+import { FC, memo, useEffect } from 'react';
+import type { IEmojiData } from 'emoji-picker-react';
+
+export type Emoji = IEmojiData;
+
+const Picker = dynamic(() => import('emoji-picker-react'), { ssr: false });
+
+interface Props {
+  onSelect: (emoji: Emoji) => void;
+  onClickOutside: () => void;
+}
+const EmojiPicker: FC<Props> = ({ onSelect, onClickOutside }) => {
+  useEffect(() => {
+    const handleClickOutside: EventListener = (event) => {
+      if (!(event.target instanceof Element)) return;
+      if (event.target.closest('.emoji-picker-react')) return;
+      onClickOutside();
+    };
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, []);
+
+  return (
+    <Picker
+      native
+      disableSearchBar
+      onEmojiClick={(event, emoji) => onSelect(emoji)}
+      pickerStyle={{
+        position: 'absolute',
+        right: '50px',
+        top: '0px',
+      }}
+    />
+  );
+};
+
+export default memo(EmojiPicker);

--- a/molecules/thread/SidePannel/SidePannel.styled.ts
+++ b/molecules/thread/SidePannel/SidePannel.styled.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { CSSzIndex } from '~/@types/style';
 
 export const Container = styled.div`
   position: absolute;
@@ -14,6 +15,7 @@ export const Container = styled.div`
 
   transition: 0.16s ease-out;
   cursor: pointer;
+  z-index: ${CSSzIndex.THREAD_SIDE_PANNEL};
 `;
 
 export const IconContainer = styled.div`

--- a/molecules/thread/SidePannel/SidePannel.tsx
+++ b/molecules/thread/SidePannel/SidePannel.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useEffect, useRef } from 'react';
+import { FC, memo, useEffect, useRef, useState } from 'react';
 import _ from 'lodash';
 import {
   ImageIcon,
@@ -11,9 +11,18 @@ import {
   GridIcon,
 } from '~/public/assets/icon';
 import { Container, IconContainer } from './SidePannel.styled';
+import { promptFileSelector } from '~/utils/file';
+import EmojiPicker, { Emoji } from './EmojiPicker';
+import { ContentType } from '~/@types/resources/thread';
+import { CreatedContent } from './types';
 
-const SidePannel: FC = () => {
+interface Props {
+  onContentCreated: (createdContent: CreatedContent) => void;
+}
+
+const SidePannel: FC<Props> = ({ onContentCreated }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const [emojiOpened, setEmojiOpened] = useState(false);
 
   useEffect(() => {
     const handleScroll = _.throttle(() => {
@@ -26,16 +35,37 @@ const SidePannel: FC = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  const handleClickImageIcon = async () => {
+    const file = await promptFileSelector();
+    console.log(file);
+  };
+
+  const handleClickSmileIcon = () => {
+    if (emojiOpened) return;
+    setEmojiOpened(true);
+  };
+
+  const handleSelectEmoji = (emoji: Emoji) => {
+    setEmojiOpened(false);
+    onContentCreated({
+      type: ContentType.EMOJI,
+      emoji: emoji.emoji,
+    });
+  };
+
   return (
-    <Container ref={ref}>
-      <IconContainer>
+    <Container ref={ref} onMouseDown={(event) => event.preventDefault()}>
+      <IconContainer onClick={handleClickImageIcon}>
         <ImageIcon />
       </IconContainer>
       <IconContainer>
         <VideoIcon />
       </IconContainer>
-      <IconContainer>
+      <IconContainer onClick={handleClickSmileIcon}>
         <SmileIcon />
+        {emojiOpened && (
+          <EmojiPicker onSelect={handleSelectEmoji} onClickOutside={() => setEmojiOpened(false)} />
+        )}
       </IconContainer>
       <IconContainer>
         <LineIcon />
@@ -56,4 +86,4 @@ const SidePannel: FC = () => {
   );
 };
 
-export default memo<FC>(SidePannel);
+export default memo<FC<Props>>(SidePannel);

--- a/molecules/thread/SidePannel/index.ts
+++ b/molecules/thread/SidePannel/index.ts
@@ -1,1 +1,2 @@
 export { default as SidePannel } from './SidePannel';
+export * from './types';

--- a/molecules/thread/SidePannel/types.ts
+++ b/molecules/thread/SidePannel/types.ts
@@ -1,0 +1,8 @@
+import { ContentType, ImageContent } from '~/@types/resources/thread';
+
+export type CreatedContent =
+  | {
+      type: ContentType.EMOJI;
+      emoji: string;
+    }
+  | ImageContent;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^0.21.1",
     "classnames": "^2.2.6",
     "dotenv": "^8.2.0",
+    "emoji-picker-react": "^3.4.4",
     "lodash": "^4.17.20",
     "luxon": "^1.26.0",
     "next": "10.0.6",

--- a/utils/dom/index.ts
+++ b/utils/dom/index.ts
@@ -23,7 +23,7 @@ export const getCaretPixel = (): DOMRect | null => {
  * get caret position
  * @returns {number}
  */
-export const getCaretNumber = (target: any): number | null => {
+export const getCaretNumber = (target?: any): number | null => {
   // for texterea/input element
   if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
     return target.selectionStart;
@@ -47,7 +47,11 @@ export const getCaretNumber = (target: any): number | null => {
     range.setEnd(_range.endContainer, _range.endOffset);
     return range.toString().length;
   }
-  return null;
+  try {
+    return document.getSelection()?.getRangeAt(0)?.endOffset ?? null;
+  } catch {
+    return null;
+  }
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,6 +2694,11 @@ emittery@^0.7.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
+emoji-picker-react@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/emoji-picker-react/-/emoji-picker-react-3.4.4.tgz#027786af60d4b7ebe04338c5456ae7ae4b3d3eb6"
+  integrity sha512-j5atTz5Uawt926Bc37MG5S0MwfIa9Gh4CVDGhnMSBhKZkDmgd5Q0QtQgcv+baLGdByYBsYx1OyQHORc6o8Ce5Q==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
### Changes
- 문서 편집 / 사이드패널의 이모티콘 입력 기능을 구현하였습니다.

<img src="https://user-images.githubusercontent.com/34727284/115538792-36715f00-a2d7-11eb-88a8-c04e131c7ca5.png" width="70%" />

### Comment
- 텍스트 블록에 focus 되어 있는 상태에서 이모티콘 추가 시 현재 caret 위치에 이모티콘을 입력합니다.
- 텍스트 블록에 focus 되어 있지 않은 상태로 이모티콘 추가 시 새 텍스트 블록을 생성한 뒤 해당 블록에 이모티콘을 입력합니다.

